### PR TITLE
Make privileged NFQUEUE bypass opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,13 @@ Configuration is stored in `/etc/bastion/config.json`:
 {
   "mode": "learning",
   "timeout_seconds": 30,
-  "allow_localhost": true
+  "allow_localhost": true,
+  "allow_root_bypass": false,
+  "allow_systemd_bypass": false
 }
 ```
+
+> **Security note:** Bypassing NFQUEUE for privileged accounts trades security for performance and convenience. Leaving `allow_root_bypass` and `allow_systemd_bypass` set to `false` ensures even root-owned/system daemons are subject to Bastion's policy checks. If you need to trust a specific service, prefer running it under a dedicated, least-privilege service account and allow that account explicitly instead of enabling global bypasses.
 
 ## Architecture
 

--- a/bastion/config.py
+++ b/bastion/config.py
@@ -16,7 +16,9 @@ class ConfigManager:
         'timeout_seconds': 30,
         'allow_localhost': True,
         'allow_lan': False,
-        'log_decisions': True
+        'log_decisions': True,
+        'allow_root_bypass': False,
+        'allow_systemd_bypass': False
     }
     
     CONFIG_PATH = Path('/etc/bastion/config.json')
@@ -48,7 +50,8 @@ class ConfigManager:
         validated['timeout_seconds'] = timeout
         
         # Validate boolean flags
-        for key in ['cache_decisions', 'allow_localhost', 'allow_lan', 'log_decisions']:
+        for key in ['cache_decisions', 'allow_localhost', 'allow_lan', 'log_decisions',
+                    'allow_root_bypass', 'allow_systemd_bypass']:
             value = config.get(key, cls.DEFAULT_CONFIG.get(key, False))
             validated[key] = bool(value)
         

--- a/bastion/daemon.py
+++ b/bastion/daemon.py
@@ -127,8 +127,8 @@ class BastionDaemon:
         self._setup_socket()
 
         # Setup iptables
-        allow_root = self.config.get('allow_root_bypass', True)
-        allow_systemd = self.config.get('allow_systemd_bypass', True)
+        allow_root = self.config.get('allow_root_bypass', False)
+        allow_systemd = self.config.get('allow_systemd_bypass', False)
         logger.info(f"Configuring iptables (Root Bypass: {allow_root}, Systemd Bypass: {allow_systemd})")
         
         if not IPTablesManager.setup_nfqueue(queue_num=1, allow_root=allow_root, allow_systemd=allow_systemd):
@@ -410,8 +410,8 @@ class BastionDaemon:
         res = subprocess.run(['iptables', '-S', 'OUTPUT'], capture_output=True, text=True)
         if 'NFQUEUE' not in res.stdout:
             logger.warning("NFQUEUE rule missing! Re-adding...")
-            allow_root = self.config.get('allow_root_bypass', True)
-            allow_systemd = self.config.get('allow_systemd_bypass', True)
+            allow_root = self.config.get('allow_root_bypass', False)
+            allow_systemd = self.config.get('allow_systemd_bypass', False)
             IPTablesManager.setup_nfqueue(queue_num=1, allow_root=allow_root, allow_systemd=allow_systemd)
 
     def _handle_packet(self, pkt_info: PacketInfo) -> bool:

--- a/bastion/firewall_core.py
+++ b/bastion/firewall_core.py
@@ -349,7 +349,7 @@ class IPTablesManager:
     """Manages iptables rules for packet queuing"""
 
     @staticmethod
-    def setup_nfqueue(queue_num=1, allow_root=True, allow_systemd=True):
+    def setup_nfqueue(queue_num=1, allow_root=False, allow_systemd=False):
         """
         Set up iptables rules to queue outbound packets.
         Ensures a clean slate before adding rules to prevent duplicates.
@@ -372,10 +372,11 @@ class IPTablesManager:
             logger.info(f"Added iptables NFQUEUE rule: {' '.join(rule)}")
 
             # Bypass NFQUEUE for root and systemd services for performance gain
-            # Only if explicitly allowed (default: True)
+            # Only if explicitly allowed (default: False)
             bypass_rules = []
             
             if allow_root:
+                logger.warning("Root bypass enabled - root traffic will skip firewall enforcement")
                 bypass_rules.append(
                     ['iptables', '-I', 'OUTPUT', '1', 
                      '-m', 'owner', '--uid-owner', '0', 
@@ -384,6 +385,7 @@ class IPTablesManager:
                 )
             
             if allow_systemd:
+                logger.warning("Systemd-network bypass enabled - systemd-networkd traffic will skip firewall enforcement")
                 bypass_rules.append(
                     ['iptables', '-I', 'OUTPUT', '1', 
                      '-m', 'owner', '--gid-owner', 'systemd-network',


### PR DESCRIPTION
## **User description**
### **User description**
## Summary
- default privileged NFQUEUE bypasses to false and add config flags to control them
- propagate bypass settings through the daemon and warn when privileged bypasses are enabled
- document security considerations and recommend least-privilege service accounts over global bypasses

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd7b8364c832897dd826d97505082)


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Change privileged NFQUEUE bypasses from opt-out to opt-in by defaulting to false

- Add configuration flags `allow_root_bypass` and `allow_systemd_bypass` to control bypasses

- Add warning logs when privileged bypasses are enabled for security awareness

- Document security considerations recommending least-privilege service accounts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Default Config<br/>allow_root_bypass: false<br/>allow_systemd_bypass: false"] --> B["Config Validation<br/>Boolean flag validation"]
  B --> C["Daemon Startup<br/>Read bypass settings"]
  C --> D["IPTablesManager<br/>setup_nfqueue"]
  D --> E["Warning Logs<br/>When bypasses enabled"]
  E --> F["Security Documentation<br/>Recommend least-privilege"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add privileged bypass configuration flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bastion/config.py

<ul><li>Add two new boolean configuration flags: <code>allow_root_bypass</code> and <br><code>allow_systemd_bypass</code> with default values of <code>False</code><br> <li> Include these new flags in the configuration validation logic to <br>ensure they are properly validated as boolean values</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/10/files#diff-bc819b8140426cf6795847ab82cd510e09bd74d2f2978dd9119000353302e188">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>daemon.py</strong><dd><code>Update daemon bypass defaults to false</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bastion/daemon.py

<ul><li>Change default values for <code>allow_root_bypass</code> and <code>allow_systemd_bypass</code> <br>from <code>True</code> to <code>False</code> in the <code>start()</code> method<br> <li> Change default values for <code>allow_root_bypass</code> and <code>allow_systemd_bypass</code> <br>from <code>True</code> to <code>False</code> in the <code>_check_nfqueue_rule()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/10/files#diff-2ca8d9a4a9ca39a1a0426350a6082a2711e584a79da1f3e53fa431a4665e1baa">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>firewall_core.py</strong><dd><code>Default bypasses to false with security warnings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bastion/firewall_core.py

<ul><li>Change <code>setup_nfqueue()</code> method signature default parameters from <code>True</code> <br>to <code>False</code> for both <code>allow_root</code> and <code>allow_systemd</code><br> <li> Add warning log messages when <code>allow_root</code> bypass is enabled to alert <br>administrators<br> <li> Add warning log message when <code>allow_systemd</code> bypass is enabled to alert <br>administrators<br> <li> Update inline comment to reflect new default behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/10/files#diff-addda00e3f7b10a3d93cf521c8ac77493dd72e358d3b82659fbff2a4d7517850">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document bypass configuration and security best practices</code></dd></summary>
<hr>

README.md

<ul><li>Add <code>allow_root_bypass</code> and <code>allow_systemd_bypass</code> configuration options <br>to the example configuration JSON<br> <li> Add security note recommending against global bypasses and suggesting <br>least-privilege service accounts as alternative</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/10/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


___

## **CodeAnt-AI Description**
Make privileged NFQUEUE bypass opt-in and warn when enabled

### What Changed
- Default configuration now disables root and systemd NFQUEUE bypasses so privileged traffic is queued and evaluated by Bastion
- Two new config options appear: allow_root_bypass and allow_systemd_bypass; they are validated and default to false
- When either bypass is explicitly enabled, the daemon logs a clear warning so operators are aware privileged traffic will skip enforcement
- README defaults and a security note were added to recommend using least-privilege service accounts instead of enabling global bypasses

### Impact
`✅ Fewer privileged bypasses by default`
`✅ Clearer security warnings when bypasses are enabled`
`✅ Consistent behavior between config, runtime, and documentation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Two new configuration options enable fine-grained control over NFQUEUE bypass behavior for privileged accounts, now defaulting to disabled for enhanced security.

* **Documentation**
  * Updated configuration examples and added security guidance regarding privileged account access through the firewall.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->