### PR TITLE
Add headless policy configuration and health check reporting

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,6 +5,8 @@
   "timeout_seconds": 30,
   "log_file": "/var/log/ufw_firewall_gui.log",
   "mode": "learning",
+  "learning_headless_policy": "deny",
+  "health_port": 8676,
   "gui": {
     "window_timeout": 30,
     "always_on_top": true,


### PR DESCRIPTION
## **User description**
### **User description**
## Summary
- add configurable learning headless policy and structured logging when GUI is unavailable
- expose a local HTTP health endpoint and CLI flag to report GUI connectivity and headless policy
- document new defaults for headless policy and health port in the sample config

## Testing
- python -m py_compile bastion/daemon.py bastion/config.py bastion-daemon.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd7ba9ef08328af4602854d2b5d3d)


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable learning headless policy for GUI unavailability scenarios

- Implement local HTTP health endpoint reporting daemon status and connectivity

- Add CLI flags for health check queries and port override configuration

- Enhance logging with structured context for headless policy decisions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CLI["CLI Arguments<br/>--health-check<br/>--health-port"]
  Config["Config Manager<br/>learning_headless_policy<br/>health_port"]
  Daemon["Bastion Daemon<br/>Health Endpoint<br/>HTTP Server"]
  GUI["GUI Connection<br/>Fallback Handling"]
  Health["Health Check<br/>Status Report"]
  
  CLI -->|"parse args"| Daemon
  Config -->|"validate config"| Daemon
  Daemon -->|"start endpoint"| Health
  Daemon -->|"headless policy"| GUI
  Health -->|"report status"| CLI
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bastion-daemon.py</strong><dd><code>Add CLI health check query functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bastion-daemon.py

<ul><li>Add <code>argparse</code> module import for CLI argument parsing<br> <li> Implement <code>--health-check</code> and <code>--health-port</code> command-line arguments<br> <li> Add health check logic to query daemon health endpoint via HTTP<br> <li> Exit early with health status before starting daemon if health check <br>requested</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/11/files#diff-55a2be3bcbc90cf4c1afecafccf777160ccd8d3238f210d8389bf79edde49628">+19/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>daemon.py</strong><dd><code>Implement health endpoint and headless policy handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bastion/daemon.py

<ul><li>Import <code>BaseHTTPRequestHandler</code>, <code>ThreadingHTTPServer</code> for health endpoint<br> <li> Add <code>health_server</code> and <code>health_thread</code> instance variables for HTTP server <br>management<br> <li> Log learning headless policy on daemon startup<br> <li> Implement <code>_start_health_endpoint()</code> method with GET handlers for <br><code>/health</code> and <code>/healthz</code> endpoints<br> <li> Enhance <code>_ask_gui()</code> method with structured logging for headless policy <br>decisions<br> <li> Implement three headless policy modes: 'allow', 'deny', and <br>'enforce_timeout'<br> <li> Add health server shutdown in <code>stop()</code> method with error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/11/files#diff-2ca8d9a4a9ca39a1a0426350a6082a2711e584a79da1f3e53fa431a4665e1baa">+86/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Add headless policy and health port configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bastion/config.py

<ul><li>Add <code>learning_headless_policy</code> default configuration with value 'deny'<br> <li> Add <code>health_port</code> default configuration with value 8676<br> <li> Implement validation for <code>learning_headless_policy</code> with allowed values: <br>'allow', 'deny', 'enforce_timeout'<br> <li> Implement validation for <code>health_port</code> ensuring valid port range 1-65535</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/11/files#diff-bc819b8140426cf6795847ab82cd510e09bd74d2f2978dd9119000353302e188">+21/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.json</strong><dd><code>Update sample config with new defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

config.json

<ul><li>Add <code>learning_headless_policy</code> configuration set to 'deny'<br> <li> Add <code>health_port</code> configuration set to 8676</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/11/files#diff-587cb980af76fdc7e52369fd0b9d926dff266976b6f8ac631e358fecc49ff8cf">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


___

## **CodeAnt-AI Description**
Add CLI health check, local health HTTP endpoint, and configurable headless policy

### What Changed
- New CLI flags --health-check and --health-port let operators query the daemon's local health endpoint and print its JSON status or an error.
- Daemon now starts a local HTTP health endpoint (127.0.0.1:<health_port>) that reports whether the daemon is running, whether the GUI is connected, the current mode, and the active learning headless policy.
- Configuration gains two new entries with defaults: learning_headless_policy (deny) and health_port (8676); invalid values are sanitized at load time.
- When the GUI is unavailable, headless policy is applied and logged: "allow" permits the connection, "deny" blocks it, and "enforce_timeout" treats it as a timed-out prompt and blocks the connection. Headless events are logged with structured context for easier diagnosis.
- Health endpoint startup is skipped if the configured port is already in use; CLI health check reports connection failures and exit codes.

### Impact
`✅ Local health status endpoint for quick diagnostics`
`✅ CLI command to get daemon GUI/connectivity status`
`✅ Predictable connection handling when GUI is missing`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
