### PR TITLE
Add startup dependency validation and self-check CLI

### DIFF
--- a/bastion/startup_validator.py
+++ b/bastion/startup_validator.py
@@ -1,0 +1,199 @@
+"""
+Centralized runtime dependency validation for Bastion.
+
+This module consolidates checks for core libraries that the daemon
+and GUI rely on. It provides clear, actionable error messages so
+operators understand what to install or fix before starting the
+firewall.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DependencyDefinition:
+    """Static definition of a dependency."""
+
+    key: str
+    module_path: str
+    display_name: str
+    install_hint: str
+    category: str  # e.g. core, packet, gui
+
+
+@dataclass
+class DependencyStatus:
+    """Result of attempting to import a dependency."""
+
+    definition: DependencyDefinition
+    state: str  # ok, missing, error
+    detail: str = ""
+
+    @property
+    def is_failure(self) -> bool:
+        return self.state != "ok"
+
+    def describe(self) -> str:
+        if self.state == "ok":
+            return f"{self.definition.display_name} available"
+
+        qualifier = "is not installed" if self.state == "missing" else "is installed but failed to load"
+        detail = f" ({self.detail})" if self.detail else ""
+        return f"{self.definition.display_name} {qualifier}{detail}. {self.definition.install_hint}"
+
+
+class DependencyValidationError(RuntimeError):
+    """Raised when one or more dependencies are unavailable."""
+
+    def __init__(self, failures: Iterable[DependencyStatus]):
+        self.failures: List[DependencyStatus] = list(failures)
+        message = "Runtime dependency validation failed:\n" + "\n".join(
+            f"- {failure.describe()}" for failure in self.failures
+        )
+        super().__init__(message)
+        self.user_message = message
+
+
+class MissingDependencyError(DependencyValidationError):
+    """Raised when a dependency is missing entirely."""
+
+
+class BrokenDependencyError(DependencyValidationError):
+    """Raised when a dependency exists but cannot be imported/used."""
+
+
+DEPENDENCIES: List[DependencyDefinition] = [
+    DependencyDefinition(
+        key="psutil",
+        module_path="psutil",
+        display_name="psutil",
+        install_hint="Install psutil (e.g., pip install psutil or your distro's python3-psutil package).",
+        category="core",
+    ),
+    DependencyDefinition(
+        key="netfilterqueue",
+        module_path="netfilterqueue",
+        display_name="NetfilterQueue",
+        install_hint="Install NetfilterQueue and libnetfilter-queue (pip install NetfilterQueue or apt install python3-netfilterqueue).",
+        category="packet",
+    ),
+    DependencyDefinition(
+        key="scapy",
+        module_path="scapy.all",
+        display_name="Scapy",
+        install_hint="Install scapy (pip install scapy or your distro's python3-scapy package).",
+        category="packet",
+    ),
+    DependencyDefinition(
+        key="tkinter",
+        module_path="tkinter",
+        display_name="Tkinter",
+        install_hint="Install the Tkinter bindings (e.g., apt install python3-tk).",
+        category="gui",
+    ),
+]
+
+DEPENDENCY_MAP: Dict[str, DependencyDefinition] = {dep.key: dep for dep in DEPENDENCIES}
+
+
+def _import_dependency(module_path: str):
+    """Separated for testability."""
+    return importlib.import_module(module_path)
+
+
+def _check_dependency(
+    definition: DependencyDefinition,
+    importer: Callable[[str], object] = _import_dependency,
+) -> DependencyStatus:
+    try:
+        importer(definition.module_path)
+        return DependencyStatus(definition=definition, state="ok")
+    except ModuleNotFoundError as exc:
+        logger.debug("Dependency %s missing: %s", definition.display_name, exc)
+        return DependencyStatus(definition=definition, state="missing", detail=str(exc))
+    except Exception as exc:  # pragma: no cover - exercised via tests
+        logger.debug("Dependency %s failed to import: %s", definition.display_name, exc)
+        return DependencyStatus(definition=definition, state="error", detail=str(exc))
+
+
+def collect_dependency_statuses(
+    include_gui: bool = True,
+    importer: Callable[[str], object] = _import_dependency,
+) -> List[DependencyStatus]:
+    """Collect the status of all runtime dependencies."""
+    statuses: List[DependencyStatus] = []
+    for definition in DEPENDENCIES:
+        if definition.category == "gui" and not include_gui:
+            continue
+        statuses.append(_check_dependency(definition, importer=importer))
+    return statuses
+
+
+def ensure_runtime_dependencies(
+    include_gui: bool = True,
+    importer: Callable[[str], object] = _import_dependency,
+) -> List[DependencyStatus]:
+    """
+    Validate that all required dependencies are importable.
+
+    Raises:
+        DependencyValidationError: when any dependency is missing or broken.
+    """
+    statuses = collect_dependency_statuses(include_gui=include_gui, importer=importer)
+    failures = [status for status in statuses if status.is_failure]
+    if failures:
+        # Distinguish missing vs broken to surface clear root causes
+        if all(status.state == "missing" for status in failures):
+            raise MissingDependencyError(failures)
+        raise BrokenDependencyError(failures)
+    return statuses
+
+
+def require_dependency(
+    key: str, importer: Callable[[str], object] = _import_dependency
+):
+    """
+    Import a specific dependency and raise a clear error on failure.
+
+    This is intended for code paths that truly need the module object.
+    """
+    if key not in DEPENDENCY_MAP:
+        raise KeyError(f"Unknown dependency key '{key}'")
+
+    definition = DEPENDENCY_MAP[key]
+    status = _check_dependency(definition, importer=importer)
+    if status.state == "ok":
+        return importer(definition.module_path)
+    if status.state == "missing":
+        raise MissingDependencyError([status])
+    raise BrokenDependencyError([status])
+
+
+def run_self_check(include_gui: bool = True, importer: Callable[[str], object] = _import_dependency) -> bool:
+    """
+    Run dependency validation and print a human-friendly report.
+
+    Returns:
+        bool: True when all required dependencies are available, False otherwise.
+    """
+    statuses = collect_dependency_statuses(include_gui=include_gui, importer=importer)
+    critical_failures = [status for status in statuses if status.is_failure]
+
+    print("Running Bastion dependency self-check...\n")
+    for status in statuses:
+        label = "OK" if not status.is_failure else ("MISSING" if status.state == "missing" else "ERROR")
+        print(f"[{label:<7}] {status.describe()}")
+
+    if critical_failures:
+        print("\nOne or more critical dependencies are unavailable. Address the issues above and retry.")
+        return False
+
+    print("\nAll critical dependencies satisfied. You can start Bastion safely.")
+    return True

--- a/scripts/bastion
+++ b/scripts/bastion
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Bastion Firewall CLI entrypoint.
+
+Currently supports a dependency self-check to help operators verify
+their environment before enabling enforcement.
+"""
+
+import argparse
+import os
+import sys
+
+# Ensure local package import works even when running from source tree
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from bastion.startup_validator import run_self_check
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bastion Firewall command-line interface")
+    parser.add_argument(
+        "--self-check",
+        action="store_true",
+        help="Validate runtime dependencies (netfilterqueue, scapy, psutil, tkinter) before starting the firewall.",
+    )
+    parser.add_argument(
+        "--skip-gui-check",
+        action="store_true",
+        help="Skip GUI-specific checks (e.g., tkinter) when running on headless hosts.",
+    )
+    args = parser.parse_args()
+
+    if args.self_check:
+        success = run_self_check(include_gui=not args.skip_gui_check)
+        sys.exit(0 if success else 1)
+
+    parser.print_help()
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
     scripts=[
         "bastion-daemon.py",
         "bastion-gui.py",
-        "bastion_control_panel.py"
+        "bastion_control_panel.py",
+        "scripts/bastion"
     ],
     # Note: entry_points removed because script files use hyphens (bastion-daemon.py)
     # which cannot be imported as Python modules. Use scripts[] instead.

--- a/tests/test_startup_validator.py
+++ b/tests/test_startup_validator.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from bastion import startup_validator as sv
+
+
+def _fake_import_factory(responses):
+    """Create a fake importer that can raise exceptions for specific modules."""
+
+    def _fake_import(module_path):
+        behavior = responses.get(module_path)
+        if isinstance(behavior, Exception):
+            raise behavior
+        return behavior or object()
+
+    return _fake_import
+
+
+def test_collect_dependency_statuses_marks_missing(monkeypatch):
+    fake_import = _fake_import_factory({"netfilterqueue": ModuleNotFoundError("no module named netfilterqueue")})
+    statuses = sv.collect_dependency_statuses(include_gui=False, importer=fake_import)
+    status_map = {status.definition.key: status for status in statuses}
+
+    assert status_map["netfilterqueue"].state == "missing"
+    assert status_map["psutil"].state == "ok"
+    assert status_map["scapy"].state == "ok"
+
+
+def test_require_dependency_distinguishes_broken(monkeypatch):
+    fake_import = _fake_import_factory({"netfilterqueue": RuntimeError("libnetfilter-queue not present")})
+    with pytest.raises(sv.BrokenDependencyError) as excinfo:
+        sv.require_dependency("netfilterqueue", importer=fake_import)
+
+    assert "libnetfilter-queue not present" in str(excinfo.value)
+
+
+def test_ensure_runtime_dependencies_raises_missing(monkeypatch):
+    fake_import = _fake_import_factory({"scapy.all": ModuleNotFoundError("scapy missing")})
+    with pytest.raises(sv.MissingDependencyError) as excinfo:
+        sv.ensure_runtime_dependencies(include_gui=False, importer=fake_import)
+
+    assert "Scapy is not installed" in excinfo.value.user_message
+
+
+def test_run_self_check_reports_statuses(capsys):
+    fake_import = _fake_import_factory({})
+    success = sv.run_self_check(include_gui=False, importer=fake_import)
+
+    out = capsys.readouterr().out
+    assert success is True
+    assert "dependency self-check" in out
+    assert "[OK" in out


### PR DESCRIPTION
## **User description**
### **User description**
## Summary
- centralize dependency validation with actionable messages for core packet-processing and GUI libraries
- guard daemon startup and packet processor initialization behind dependency validation
- add a `bastion --self-check` CLI and tests for the validator

## Testing
- pytest tests/test_startup_validator.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd7bc0b808328b470420a4106172f)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Centralize runtime dependency validation with clear, actionable error messages

- Add `bastion --self-check` CLI command for operators to verify environment

- Defer heavy imports until dependencies verified to prevent system state mutation

- Guard daemon startup and packet processor initialization behind validation checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Daemon startup"] --> B["Validate dependencies"]
  B --> C{Dependencies OK?}
  C -->|No| D["Log error & exit cleanly"]
  C -->|Yes| E["Defer imports & initialize"]
  E --> F["Start packet processor"]
  G["CLI --self-check"] --> H["Run self-check"]
  H --> I["Report dependency status"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>startup_validator.py</strong><dd><code>New centralized dependency validation module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bastion/startup_validator.py

<ul><li>New module providing centralized dependency validation framework<br> <li> Defines <code>DependencyDefinition</code>, <code>DependencyStatus</code>, and exception classes <br>(<code>DependencyValidationError</code>, <code>MissingDependencyError</code>, <br><code>BrokenDependencyError</code>)<br> <li> Implements <code>ensure_runtime_dependencies()</code> to validate all required <br>imports with clear error messages<br> <li> Provides <code>require_dependency()</code> for on-demand dependency loading with <br>error handling<br> <li> Includes <code>run_self_check()</code> for CLI reporting of dependency status</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/12/files#diff-3a5d8db8003f3c5c5184525f61808f1c60fc93b417921a948dbea53cc3cbed51">+199/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>daemon.py</strong><dd><code>Guard startup with dependency validation and defer imports</code></dd></summary>
<hr>

bastion/daemon.py

<ul><li>Add dependency validation at daemon startup before system state <br>mutation<br> <li> Defer imports of <code>PacketProcessor</code>, <code>IPTablesManager</code> until dependencies <br>verified<br> <li> Use <code>TYPE_CHECKING</code> to avoid circular imports while maintaining type <br>hints<br> <li> Store <code>iptables_manager</code> as instance variable for consistent access<br> <li> Add exception handling for <code>PacketProcessor</code> initialization with cleanup <br>on failure<br> <li> Update <code>_check_nfqueue_rule()</code> and <code>stop()</code> to use instance <br><code>iptables_manager</code></ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/12/files#diff-2ca8d9a4a9ca39a1a0426350a6082a2711e584a79da1f3e53fa431a4665e1baa">+43/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firewall_core.py</strong><dd><code>Use centralized validator and defer netfilter imports</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bastion/firewall_core.py

<ul><li>Replace try-except import pattern with <code>require_dependency()</code> calls in <br><code>PacketProcessor.__init__()</code><br> <li> Store imported module objects (<code>NetfilterQueue</code>, <code>IP</code>, <code>TCP</code>, <code>UDP</code>) as <br>instance attributes<br> <li> Update <code>process_packet()</code> to use instance attributes instead of <br>module-level globals<br> <li> Remove module-level <code>NETFILTER_AVAILABLE</code> flag and related checks<br> <li> Propagate dependency errors up to daemon for clean startup abort</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/12/files#diff-addda00e3f7b10a3d93cf521c8ac77493dd72e358d3b82659fbff2a4d7517850">+26/-22</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bastion</strong><dd><code>New CLI entrypoint with self-check command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/bastion

<ul><li>New CLI entrypoint script for Bastion Firewall<br> <li> Implements <code>--self-check</code> flag to validate runtime dependencies<br> <li> Implements <code>--skip-gui-check</code> flag for headless environments<br> <li> Provides help text and argument parsing</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/12/files#diff-ca657211aab255e028b794d483a8a116f930c99f3989cc7d6115e5038f86378b">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_startup_validator.py</strong><dd><code>Test suite for dependency validation module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_startup_validator.py

<ul><li>New test module with 5 test cases covering dependency validation<br> <li> Tests missing dependency detection, broken dependency distinction, and <br>error messages<br> <li> Includes <code>run_self_check()</code> output validation<br> <li> Uses factory pattern for fake importers to simulate various failure <br>scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/12/files#diff-adca82682ed7107a4daf09937f4ac0fa09b60b7bb65888f496e49e3592d764d7">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.py</strong><dd><code>Register new CLI script in setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup.py

<ul><li>Add <code>scripts/bastion</code> to scripts list for CLI installation<br> <li> Maintains existing dependency declarations</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/12/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___


___

## **CodeAnt-AI Description**
**Centralize runtime dependency checks and add a self-check CLI**

### What Changed
- Daemon now validates required libraries (netfilterqueue, scapy, psutil, tkinter) before touching iptables or starting packet processing; on failure it logs and exits cleanly with clear, actionable messages.
- Heavy imports are deferred until after validation so the process no longer mutates system state (iptables NFQUEUE setup is skipped if validation fails).
- Packet processor now fails with explicit dependency errors when packet libraries are missing or broken, and the daemon cleans up iptables if initialization fails.
- New CLI script "bastion" exposes a --self-check command to print a human-readable report of missing or broken dependencies; tests verify validator behavior and messages.

### Impact
`✅ Fewer daemon startup crashes due to missing libraries`
`✅ Clearer, actionable dependency error messages for operators`
`✅ Safer iptables state when startup fails`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
