### PR TITLE
feat(whitelist): auto-allow mDNS multicast traffic

### DIFF
--- a/bastion-rs/src/whitelist.rs
+++ b/bastion-rs/src/whitelist.rs
@@ -83,6 +83,12 @@ pub fn should_auto_allow(app_path: &str, app_name: &str, dest_port: u16, dest_ip
         }
     }
 
+    // 1b. mDNS multicast (224.0.0.251:5353) - local network service discovery
+    // Used by Avahi, Chrome (Chromecast), printers, etc. Never leaves LAN.
+    if dest_ip == "224.0.0.251" && dest_port == 5353 {
+        return (true, "mDNS (local)");
+    }
+
     // 2. DNS traffic - auto-allow for trusted binaries OR unknown processes
     if dest_port == 53 {
         if SYSTEM_PATHS.contains(app_path) || app_path.starts_with("/usr/lib/systemd/") {


### PR DESCRIPTION
## **User description**
### **User description**
## Summary
Add 224.0.0.251:5353 (mDNS) to service whitelist.

## What is mDNS?
mDNS (multicast DNS) is used for local network service discovery:
- **Avahi** - Linux service discovery daemon
- **Chrome/Chromium** - Chromecast device discovery
- **Printers** - Network printer discovery
- **Local hostnames** - Resolution of `.local` domain names

## Why auto-allow?
mDNS is **local multicast only** - it never leaves the LAN segment. The multicast address 224.0.0.251 is link-local, meaning packets are not routed beyond the local network.

Blocking mDNS causes:
- Chromecast not being discovered
- Network printers not appearing
- `.local` hostname resolution failures
- Excessive popups for harmless local traffic

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author


___

### **PR Type**
Enhancement


___

### **Description**
- Add mDNS multicast (224.0.0.251:5353) to service whitelist

- Enable local network service discovery for Avahi, Chromecast, printers

- Prevent blocking of harmless link-local multicast traffic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["should_auto_allow function"] -- "checks dest_ip and dest_port" --> B["mDNS check: 224.0.0.251:5353"]
  B -- "matches" --> C["Return true with mDNS label"]
  B -- "no match" --> D["Continue to DNS checks"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>whitelist.rs</strong><dd><code>Add mDNS multicast whitelist check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

bastion-rs/src/whitelist.rs

<ul><li>Added mDNS multicast address check (224.0.0.251:5353) in <br><code>should_auto_allow</code> function<br> <li> Returns auto-allow decision with "mDNS (local)" label for matching <br>traffic<br> <li> Positioned after localhost checks and before DNS traffic validation<br> <li> Includes explanatory comments about mDNS usage and local-only scope</ul>


</details>


  </td>
  <td><a href="https://github.com/shipdocs/bastion-firewall/pull/24/files#diff-937a7f41c555573f431cef9c8d0a21808ffd5eab76a727af3fa167760b4eeb9c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of local network discovery traffic to ensure mDNS services (such as device discovery and local network communication) are properly allowed without unnecessary blocking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Auto-allow mDNS multicast (224.0.0.251:5353) for local service discovery**

### What Changed
- The application now automatically permits mDNS multicast traffic to 224.0.0.251:5353
- Local network service discovery (Chromecast, network printers, Avahi, and .local hostname resolution) works without being blocked
- Harmless link-local multicast traffic remains confined to the LAN and will no longer trigger blocking-related failures or popups

### Impact
`✅ Chromecast and other devices are discoverable on LAN`
`✅ Fewer "device not found" or printer discovery failures`
`✅ Fewer user-facing popups for benign local network traffic`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
